### PR TITLE
Improve magic link sign-in experience

### DIFF
--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -1,15 +1,62 @@
-'use server'
+"use server"
 
 import { signIn, signOut } from "@/lib/auth"
+import { AuthError } from "next-auth"
 
-export async function handleSignIn() {
-	// magic link and google both 
-	await signIn("credentials", { redirectTo: "/app" })
-	//redirect to app
-	// redirect("/app")
-	// await signIn("nodemailer", { redirectTo: "/app" })
+export type SignInState = {
+  error?: string
+  success?: string
+}
+
+export async function handleSignIn(
+  _prevState: SignInState | undefined,
+  formData: FormData
+): Promise<SignInState> {
+  const email = formData.get("email")
+
+  if (!email || typeof email !== "string") {
+    return {
+      error: "Please enter a valid email address to receive a login link.",
+    }
+  }
+
+  const normalizedEmail = email.trim()
+
+  if (!normalizedEmail) {
+    return {
+      error: "Please enter a valid email address to receive a login link.",
+    }
+  }
+
+  try {
+    await signIn("nodemailer", {
+      email: normalizedEmail,
+      redirectTo: "/app",
+    })
+
+    return {
+      success: "Check your inbox for a magic link to continue.",
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      switch (error.type) {
+        case "OAuthAccountNotLinked":
+          return {
+            error: "Please sign in using the same provider you used previously.",
+          }
+        default:
+          return {
+            error: "We couldn't sign you in. Please try again.",
+          }
+      }
+    }
+
+    return {
+      error: "Something went wrong. Please try again in a moment.",
+    }
+  }
 }
 
 export async function handleSignOut() {
-	await signOut({ redirectTo: "/" })
-} 
+  await signOut({ redirectTo: "/" })
+}

--- a/components/sign-in.tsx
+++ b/components/sign-in.tsx
@@ -1,17 +1,54 @@
-import { handleSignIn } from "@/app/actions/auth"
-import config from "@/config";
+"use client"
+
+import { handleSignIn, type SignInState } from "@/app/actions/auth"
+import { useFormState, useFormStatus } from "react-dom"
+
+const initialState: SignInState = {}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <button
+      type="submit"
+      className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 disabled:opacity-60"
+      disabled={pending}
+    >
+      {pending ? "Sending..." : "Send magic link"}
+    </button>
+  )
+}
 
 export default function SignIn() {
-	return (
+  const [state, formAction] = useFormState(handleSignIn, initialState)
 
-		<form action={handleSignIn}>
-			<button
-				type="submit"
-				className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200"
-
-			>
-				Sign In
-			</button>
-		</form>
-	);
-} 
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <form action={formAction} className="flex items-center gap-2">
+        <label htmlFor="email" className="sr-only">
+          Email address
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          placeholder="you@example.com"
+          autoComplete="email"
+          className="w-56 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <SubmitButton />
+      </form>
+      {state.error ? (
+        <p className="text-sm text-red-600" role="alert">
+          {state.error}
+        </p>
+      ) : null}
+      {state.success ? (
+        <p className="text-sm text-green-600" role="status">
+          {state.success}
+        </p>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- update the server action to submit nodemailer sign-ins with email validation, friendly messaging, and redirect configuration
- convert the sign-in component into a client form that collects an email address and surfaces success or error feedback

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8cde1e9c83339f5586f5e84a1e28