### PR TITLE
Update middleware matcher for app subpaths

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,7 @@ import NextAuth from "next-auth"
 import { NextResponse } from "next/server"
 
 export const config = {
-	matcher: ["/app"],
+        matcher: ["/app/:path*"],
 };
 
 const { auth } = NextAuth(authConfig)


### PR DESCRIPTION
## Summary
- extend the NextAuth middleware matcher to cover all routes beneath /app so authentication is enforced consistently

## Testing
- pnpm build *(fails: Build error occurred - Failed to collect page data for /api/checkout; Neither apiKey nor config.authenticator provided)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8ce157dc8333b80b3dd4089ca15c