### PR TITLE
Fix refund endpoint error handling

### DIFF
--- a/app/api/(payment)/refund/route.ts
+++ b/app/api/(payment)/refund/route.ts
@@ -4,46 +4,67 @@ import { stripe } from '@/utils/stripe';
 import { auth } from '@/lib/auth';
 
 export async function POST(request: Request) {
-	try {
-		const userSession = await auth()
-		const userId = userSession?.user?.id
-		if (!userId) {
-			return new Response('User ID is required', { status: 400 });
-		}
-		const { subscriptionId } = await request.json();
-		if (!subscriptionId) {
-			const paymentIntentId = await getPaymentIntentId(subscriptionId);
-			if (!paymentIntentId) {
+  try {
+    const userSession = await auth();
+    const userId = userSession?.user?.id;
+    if (!userId) {
+      return new Response('User ID is required', { status: 400 });
+    }
 
-				//refund the payment
-				const refund = await stripe.refunds.create({
-					payment_intent: paymentIntentId as string,
-				});
-				return NextResponse.json({ refund }, { status: 200 });
-			}
-			return new Response('Payment Intent ID is required', { status: 400 });
-		}
+    const { subscriptionId } = await request.json();
 
-	} catch (error: any) {
-		console.error(error);
-		return NextResponse.json({ message: error.message }, { status: 500 });
-	}
+    if (!subscriptionId) {
+      console.warn('[Refund] Missing subscription ID in request payload.');
+      return new Response('Subscription ID is required', { status: 400 });
+    }
+
+    const paymentIntentId = await getPaymentIntentId(subscriptionId);
+
+    if (!paymentIntentId) {
+      console.warn(
+        `[Refund] No payment intent found for subscription ${subscriptionId}.`,
+      );
+      return new Response('Payment for subscription not found', { status: 400 });
+    }
+
+    const refund = await stripe.refunds.create({
+      payment_intent: paymentIntentId,
+    });
+
+    return NextResponse.json({ refund }, { status: 200 });
+  } catch (error: any) {
+    console.error(error);
+    return NextResponse.json({ message: error.message }, { status: 500 });
+  }
 }
 
 async function getPaymentIntentId(subscriptionId: string) {
-	try {
-		// Get subscription information  english comment please
-		const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  try {
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
 
-		// Get the latest invoice
-		const latestInvoice = await stripe.invoices.retrieve(subscription.latest_invoice as string);
+    if (!subscription.latest_invoice) {
+      console.warn(
+        `[Refund] Subscription ${subscriptionId} does not have a latest invoice.`,
+      );
+      return null;
+    }
 
-		// Get the paymentIntentId
-		const paymentIntentId = latestInvoice.payment_intent;
+    const latestInvoice = await stripe.invoices.retrieve(
+      subscription.latest_invoice as string,
+    );
 
-		return paymentIntentId;
-	} catch (error) {
-		console.error('Get PaymentIntent ID error:', error);
-		throw new Error('Cannot get PaymentIntent ID');
-	}
+    const paymentIntent = latestInvoice.payment_intent;
+
+    if (!paymentIntent) {
+      console.warn(
+        `[Refund] Latest invoice ${latestInvoice.id} has no payment intent.`,
+      );
+      return null;
+    }
+
+    return typeof paymentIntent === 'string' ? paymentIntent : paymentIntent.id;
+  } catch (error) {
+    console.error('Get PaymentIntent ID error:', error);
+    throw new Error('Cannot get PaymentIntent ID');
+  }
 }


### PR DESCRIPTION
## Summary
- require a subscription ID before processing refunds
- fetch the payment intent for the subscription and return a 400 when it is missing
- add warning logs for missing subscription or payment data to aid debugging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8ce288f08333ac9f0110a0724c8e